### PR TITLE
Updates tslint with semicolon always rule

### DIFF
--- a/tslint.js
+++ b/tslint.js
@@ -65,7 +65,7 @@ module.exports = {
     "import-spacing": true,
     "no-irregular-whitespace": true,
     "interface-name": [true, "never-prefix"],
-    "semicolon": false,
+    "semicolon": [true, "always"],
 
     // Rules we do not want to enforce
     // -------------------------------------------------------


### PR DESCRIPTION
Updates semicolon rule, semicolons should be enforced.
More info here: https://palantir.github.io/tslint/rules/semicolon.