### PR TITLE
Remove no-unused-variable

### DIFF
--- a/tslint.js
+++ b/tslint.js
@@ -29,7 +29,6 @@ module.exports = {
     "no-use-before-declare": false,
     // strict: N/A
     // space-infix-ops: N/A
-    "no-unused-variable": true,
     // func-style: N/A
     "ter-arrow-parens": [true, "as-needed"],
     // no-mixed-operators: N/A


### PR DESCRIPTION
Still getting the following error when running `yarn lint`, probably we will deprecate tslint at some points but for now hopefully this warning will disappear: 
"no-unused-variable is deprecated. Since TypeScript 2.9. Please use the built-in compiler checks instead."